### PR TITLE
improve console with sequenced DAT messages

### DIFF
--- a/bramble/src/cmd/console.c
+++ b/bramble/src/cmd/console.c
@@ -38,7 +38,8 @@
 
 #include "src/libbramble/bramble.h"
 
-#define CAN_TIMEOUT 0.5
+#define CAN_TIMEOUT 0.5         // ack/nack timeout on WO
+#define CAN_RECV_TIMEOUT 5.0    // eot timeout on DAT messages
 
 static int              srcaddr;
 static int              dstaddr;
@@ -50,6 +51,7 @@ static int              console_objid = CANMSG_OBJ_CONSOLESEND;
 static ev_io            can_watcher;
 static ev_io            stdin_watcher;
 static ev_timer         timeout_watcher;
+static ev_timer         recv_timeout_watcher;
 
 const char              *timeout_message;
 
@@ -148,14 +150,63 @@ static void console_send_ack (void)
         die ("can send error: %s\n", strerror (errno));
 }
 
+static struct canmsg chunk[16];
+static size_t chunklen = sizeof (chunk) / sizeof (chunk[0]);
+
+static bool chunk_is_complete (bool holes_ok)
+{
+    int i;
+
+    for (i = 0; i < chunklen; i++) {
+        if (!holes_ok && chunk[i].dlen == 0)
+            break;
+        if (chunk[i].eot)
+            return true;
+    }
+    return false;
+}
+
+static void write_chunk_to_stdout (void)
+{
+    int i;
+
+    for (i = 0; i < chunklen; i++) {
+        if (chunk[i].dlen > 0) {
+            if (write (STDOUT_FILENO, chunk[i].data, chunk[i].dlen) < 0)
+                die ("error writing to stdout: %s\n", strerror (errno));
+            if (chunk[i].eot)
+                break;
+        }
+    }
+}
+
 static void handle_recv_dat (struct canmsg *msg)
 {
-    int n;
+    if (!ev_is_active (&recv_timeout_watcher)) {
+        ev_timer_set (&recv_timeout_watcher, CAN_RECV_TIMEOUT, 0.);
+        ev_timer_start (loop, &recv_timeout_watcher);
+    }
+    chunk[msg->seq] = *msg;
 
-    if ((n = write (STDOUT_FILENO, msg->data, msg->dlen)) < 0)
-        die ("error writing to stdout: %s\n", strerror (errno));
-    if (msg->eot)
+    if (chunk_is_complete (false)) {
+        write_chunk_to_stdout ();
+        memset (chunk, 0, sizeof (chunk));
         console_send_ack ();
+        ev_timer_stop (loop, &recv_timeout_watcher);
+    }
+}
+
+static void recv_timeout_cb (EV_P_ ev_timer *w, int revents)
+{
+    if (chunk_is_complete (true)) {
+        write_chunk_to_stdout ();
+        memset (chunk, 0, sizeof (chunk));
+        console_send_ack ();
+    }
+    else { // if eot not received in timeout, let conman restart connection
+        console_disconnect ();
+        die ("receive timeout\n");
+    }
 }
 
 /* Restart stdin watcher when previous DAT message has been ACKed.
@@ -296,6 +347,7 @@ int console_main (int argc, char *argv[])
     ev_io_init (&stdin_watcher, stdin_cb, 0, EV_READ);
 
     ev_timer_init (&timeout_watcher, timeout_cb, 0., 0.);
+    ev_timer_init (&recv_timeout_watcher, recv_timeout_cb, 0., 0.);
 
     console_connect (); // takes ACK in event loop
 

--- a/firmware/src/canservices.c
+++ b/firmware/src/canservices.c
@@ -250,8 +250,8 @@ static void canservices_console_task (void *arg __attribute((unused)))
                 trace_printf ("can-console: error sending console data\n");
                 continue;
             }
-            if (msg.eot) {
-                vTaskSuspend (console.task); // suspend task, pending ACK
+            if (msg.eot) { // suspend task pending ACK
+                ulTaskNotifyTake (pdTRUE, pdMS_TO_TICKS (500));
                 seq = 0;
             }
         }
@@ -297,7 +297,7 @@ static void canservices_rx_task (void *arg __attribute((unused)))
                     break;
                 case CANMSG_TYPE_ACK:
                     if (console.connected && msg.object == console.object)
-                        vTaskResume (console.task);
+                        xTaskNotifyGive (console.task);
                     break;
                 case CANMSG_TYPE_NAK:
                 case CANMSG_TYPE_SIG:

--- a/firmware/src/canservices.c
+++ b/firmware/src/canservices.c
@@ -213,13 +213,16 @@ static void canservices_consolerecv (const struct canmsg *request)
     if (serial_send (request->data, request->dlen, 0) < request->dlen)
         goto error;
 
-    msg.type = CANMSG_TYPE_ACK;
-    msg.dst = msg.src;
-    msg.src = srcaddr;
-    msg.dlen = 0;
-
-    if (send_msg (&msg) < 0)
-        trace_printf ("can-rx: error sending console data response\n");
+    if (request->eot) {
+        msg.type = CANMSG_TYPE_ACK;
+        msg.dst = msg.src;
+        msg.src = srcaddr;
+        msg.dlen = 0;
+        msg.eot = 0;
+        msg.seq = 0;
+        if (send_msg (&msg) < 0)
+            trace_printf ("can-rx: error sending console data response\n");
+    }
     return;
 error:
     send_nak (request);

--- a/firmware/src/serial.c
+++ b/firmware/src/serial.c
@@ -63,6 +63,11 @@ void usart1_isr (void)
     portYIELD_FROM_ISR (woke);
 }
 
+int serial_recv_available (void)
+{
+    return xStreamBufferBytesAvailable (serialrxq);
+}
+
 int serial_recv (unsigned char *buf, int bufsize, int timeout)
 {
     int ticks = timeout >= 0 ? pdMS_TO_TICKS (timeout) : portMAX_DELAY;

--- a/firmware/src/serial.h
+++ b/firmware/src/serial.h
@@ -13,6 +13,8 @@ void serial_init (void);
 int serial_recv (unsigned char *buf, int len, int timeout);
 int serial_send (const unsigned char *buf, int len, int timeout);
 
+int serial_recv_available (void);
+
 void serial_rx_enable (void);
 void serial_rx_disable (void);
 


### PR DESCRIPTION
When the 115kbaud console is streaming, such as when the system initially boots up, the lock-step DAT/ACK protocol cannot keep up and data is lost.  Change the protocol to allow up to 16 DAT messages to be sent for every ack.  Use the sequence number and eot fields of the ID to sequence and terminate the block of DATs.  The sequence starts over at zero at every eot.