### PR TITLE
firmware/blink: change RTOS LED duty cycle

### DIFF
--- a/firmware/src/blink.c
+++ b/firmware/src/blink.c
@@ -16,8 +16,10 @@
 static void blink_task (void *args __attribute((unused)))
 {
     for (;;) {
-        gpio_toggle (GPIOC, GPIO13);
-        vTaskDelay (pdMS_TO_TICKS (500));
+        gpio_clear (GPIOC, GPIO13); // on
+        vTaskDelay (pdMS_TO_TICKS (1));
+        gpio_set (GPIOC, GPIO13); // off
+        vTaskDelay (pdMS_TO_TICKS (2000));
     }
 }
 


### PR DESCRIPTION
Problem: green light is spending too much time on.
It's annoying.

Instead of toggling the LED every 500ms, turn it on for
1ms and then off for 2000ms.