### PR TITLE
add bramble usage-bargraph tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,35 @@
+# http://www.gnu.org/software/automake
+Makefile.in
+# http://www.gnu.org/software/autoconf
+autom4te.cache
+compile
+configure
+aclocal.m4
+stamp-h1
+aclocal.m4
+config.guess
+config.sub
+depcomp
+install-sh
+ltmain.sh
+missing
+config.log
+config.status
+config.h
+config.h.in
+config.h.in~
+libtool
+.deps/
+.libs/
+libltdl
+# libtool pull-ins
+/config/libtool.m4
+/config/ltoptions.m4
+/config/ltsugar.m4
+/config/ltversion.m4
+/config/lt~obsolete.m4
+
+
 # Object files
 *.o
 *.ko

--- a/bramble/Makefile.am
+++ b/bramble/Makefile.am
@@ -30,7 +30,9 @@ src_libbramble_libbramble_la_SOURCES = \
     src/libbramble/canobj.c \
     src/libbramble/i2clinux.h \
     src/libbramble/i2clinux.c \
-    src/libbramble/i2cproto.h
+    src/libbramble/i2cproto.h \
+    src/libbramble/proc.c \
+    src/libbramble/proc.h
 
 powermanconfdir = $(sysconfdir)/powerman
 

--- a/bramble/Makefile.am
+++ b/bramble/Makefile.am
@@ -14,7 +14,8 @@ src_cmd_bramble_SOURCES = \
     src/cmd/led.c \
     src/cmd/power.c \
     src/cmd/console.c \
-    src/cmd/firmware-version.c
+    src/cmd/firmware-version.c \
+    src/cmd/usage_bargraph.c
 
 src_cmd_bramble_LDADD = \
     src/libbramble/libbramble.la

--- a/bramble/src/cmd/bramble.c
+++ b/bramble/src/cmd/bramble.c
@@ -15,6 +15,7 @@ int firmware_version_main (int argc, char **argv);
 int power_main (int argc, char **argv);
 int console_main (int argc, char **argv);
 int led_main (int argc, char **argv);
+int usage_bargraph_main (int argc, char **argv);
 
 struct subcmd {
     const char *name;
@@ -30,6 +31,9 @@ static const struct subcmd builtins[] = {
     { "powerman-helper",    "power on/off slots",  power_main},
     { "conman-helper",      "netcat-like CAN console access",  console_main},
     { "led",                "update LED matrix display",  led_main},
+    { "usage-bargraph",
+      "show cpu utilization on LED matrix",
+       usage_bargraph_main},
 };
 static const int builtins_count = sizeof (builtins) / sizeof (builtins[0]);
 

--- a/bramble/src/cmd/usage_bargraph.c
+++ b/bramble/src/cmd/usage_bargraph.c
@@ -1,0 +1,99 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+#include <math.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+#include "src/libbramble/bramble.h"
+
+/* Currently, if the actual number of cpus in /proc/stat does not match
+ * NR_CPUS, we soldier on but complain about it, assuming it's a transient
+ * I/O error.
+ */
+#define NR_CPUS 4
+
+/* The display can show a bargraph of up to 5 cpus with 7 bars each.
+ * This could be transposed to show up to 7 cpus with 5 bars each, if needed.
+ * After that, maybe we need a different display, or just show one bar for
+ * the overall usage.
+ */
+#define NR_COLS 5
+#define NR_ROWS 7
+
+#ifndef min
+#define min(x,y) ((x)>(y)?(y):(x))
+#endif
+
+/* How often (seconds) is the display updated?
+ */
+static const int update_period = 1;
+
+static void update_display (uint8_t cols[NR_COLS])
+{
+    int fd;
+
+    if ((fd = i2c_open (BRAMBLE_I2C_DEVICE, I2C_ADDRESS)) < 0) {
+        warn ("%s: %s\n", BRAMBLE_I2C_DEVICE, strerror (errno));
+        return;
+    }
+    if (i2c_write (fd, I2C_REG_MATRIX_RAW, cols, NR_COLS) < 0)
+        warn ("i2c write: %s\n", strerror (errno));
+    close (fd);
+}
+
+static void create_bargraphs (double used[NR_CPUS], uint8_t cols[NR_COLS])
+{
+    for (int i = 0; i < min (NR_CPUS, NR_COLS); i++) {
+        int n = floor (used[i] * NR_ROWS); // n is the number of "on" pixels
+        for (int j = NR_ROWS - 1; j >= 0; j--) { // top row is 0
+            if (n-- == 0)
+                break;
+            cols[i] |= 1<<j;
+        }
+    }
+}
+
+int usage_bargraph_main (int argc, char *argv[])
+{
+    struct proc_cpu last[NR_CPUS];
+    struct proc_cpu cur[NR_CPUS];
+    int count = 0;
+    uint8_t cols[NR_COLS];
+    int n;
+
+    for (;;) {
+        memcpy (&last, &cur, sizeof (cur));
+        memset (&cur, 0, sizeof (cur));
+        n = proc_stat_get_cpus (cur, NR_CPUS);
+        if (n != NR_CPUS) {
+            /* N.B. If proc_stat_get_cpus() fails for some reason, it could
+             * return -1 or any number between 0 and the actual number of CPUs.
+             * Unfilled structs are zeroed above, and proc_stat_calc_cpu_usage()
+             * handles a zeroed sample by returning zero usage.
+             */
+            warn ("read %d cpus from /proc/stats, expected %d", n, NR_CPUS);
+        }
+        if (count++ > 0) {
+            double used[NR_CPUS];
+
+            for (int i = 0; i < NR_CPUS; i++)
+                used[i] = proc_stat_calc_cpu_usage (&last[i], &cur[i]);
+
+            memset (cols, 0, sizeof (cols));
+            create_bargraphs (used, cols);
+            update_display (cols);
+        }
+        sleep (update_period);
+        count++;
+    }
+
+    return 0;
+}
+
+// vi:ts=4 sw=4 expandtab
+

--- a/bramble/src/libbramble/bramble.h
+++ b/bramble/src/libbramble/bramble.h
@@ -11,6 +11,7 @@
 #include "i2cproto.h"
 
 #include "utils.h"
+#include "proc.h"
 
 #endif /* _BRAMBLE_H */
 

--- a/bramble/src/libbramble/proc.c
+++ b/bramble/src/libbramble/proc.c
@@ -1,0 +1,122 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "src/libbramble/bramble.h"
+
+#define PATH_PROC_STAT "/proc/stat"
+
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
+static bool read_proc_stat_cpu (FILE *f, struct proc_cpu *cpu)
+{
+    char buf[2048];
+    struct proc_cpu tmp;
+    char *cp;
+
+    if (fgets (buf, sizeof (buf), f) == NULL
+        || !(cp = strchr (buf, ' '))
+        || (cp - buf) >= CPU_NAME_SIZE // cpu.name would overflow
+        || sscanf (buf,
+                   "%[^ ] "
+                   "%d %d %d %d %d %d %d %d %d %d",
+                   tmp.name,
+                   &tmp.user,
+                   &tmp.nice,
+                   &tmp.system,
+                   &tmp.idle,
+                   &tmp.iowait,
+                   &tmp.irq,
+                   &tmp.softirq,
+                   &tmp.steal,
+                   &tmp.guest,
+                   &tmp.guest_nice) != 11
+        || strncmp (tmp.name, "cpu", 3) != 0)
+        return false;
+    *cpu = tmp;
+    return true;
+}
+
+/* read the first entry which should be called "cpu" (no numerical suffix).
+ */
+int proc_stat_get_cpu (struct proc_cpu *cpu)
+{
+    FILE *f;
+    struct proc_cpu tmp;
+
+    if (!(f = fopen (PATH_PROC_STAT, "r")))
+        return -1;
+    if (!read_proc_stat_cpu (f, &tmp)
+        || strcmp (tmp.name, "cpu") != 0) {
+        fclose (f);
+        return -1;
+    }
+    fclose (f);
+    *cpu = tmp;
+    return 0;
+}
+
+/* skip the first entry called "cpU", then read the next 'count' entries.
+ */
+int proc_stat_get_cpus (struct proc_cpu *cpu, size_t count)
+{
+    FILE *f;
+    struct proc_cpu tmp;
+    int n = 0;
+
+    if (!(f = fopen (PATH_PROC_STAT, "r")))
+        return -1;
+    if (!read_proc_stat_cpu (f, &tmp)
+        || strcmp (tmp.name, "cpu") != 0)
+        return -1;
+    while (n < count) {
+        if (!read_proc_stat_cpu (f, &cpu[n]))
+            break;
+        n++;
+    }
+    fclose (f);
+    return n;
+}
+
+static int cpu_idle (struct proc_cpu *x)
+{
+    return x->idle + x->iowait;
+}
+
+static int cpu_total (struct proc_cpu *x)
+{
+    return cpu_idle (x)
+         + x->user
+         + x->nice
+         + x->system
+         + x->irq
+         + x->softirq
+         + x->steal;
+}
+
+double proc_stat_calc_cpu_usage (struct proc_cpu *sample1,
+                                 struct proc_cpu *sample2)
+{
+    double total[2] = { cpu_total (sample1), cpu_total (sample2) };
+    double idle[2] =  { cpu_idle (sample1),  cpu_idle (sample2) };
+    double total_delta = total[1] - total[0];
+    double idle_delta = idle[1] - idle[0];
+
+    if (total[0] == 0
+        || total[1] == 0
+        || total_delta <= 0)
+        return 0; // bad sample?
+
+    return (total_delta - idle_delta) / total_delta;
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */
+

--- a/bramble/src/libbramble/proc.h
+++ b/bramble/src/libbramble/proc.h
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#ifndef _BRAMBLE_PROC_H
+#define _BRAMBLE_PROC_H
+
+/* Times per cpu, in USER_HZ units, since boot.
+ * See proc(5).
+ */
+#define CPU_NAME_SIZE 16
+struct proc_cpu {
+    char name[CPU_NAME_SIZE];  // cpu name (cpu, cpu0, cpu1, ...)
+    int user;       // time spent in user mode
+    int nice;       // time spent in user mode with low priority (nice)
+    int system;     // time spent in system mode
+    int idle;       // time spent in the idle stack
+    int iowait;     // time waiting for I/O to complete (unreliable)
+    int irq;        // time servicing interrupts
+    int softirq;    // time servicing softirqs
+    int steal;      // stolen time (in virtualized env)
+    int guest;      // time spent running a virtual CPU for guests
+    int guest_nice; // time spent running a niced guest
+};
+
+/* Get the overall CPU usage.
+ * Returns 0 on success, -1 on failure.
+ */
+int proc_stat_get_cpu (struct proc_cpu *cpu);
+
+/* Get the CPU usage for each CPU (up to count).
+ * 'cpu' is a pre-allocated array of 'proc_cpu' structures.
+ * Returns the number of structures filled, or -1 on error.
+ */
+int proc_stat_get_cpus (struct proc_cpu *cpu, size_t count);
+
+/* Given two usage samples, compute the fraction "used" (between 0 and 1).
+ * If one or both of the samples is all zeroes, return 0.
+ */
+double proc_stat_calc_cpu_usage (struct proc_cpu *sample1,
+                                 struct proc_cpu *sample2);
+
+#endif /* !_BRAMBLE_PROC */
+
+// vi:ts=4 sw=4 expandtab


### PR DESCRIPTION
Add a tool that continuously monitors /proc/stat and updates the matrix display to show a bargraph for each of the 4 pi cpu cores.

For now, run like this
```
$ pdsh -g all bramble usage-bargraph
```