### PR TITLE
start usage monitor automatically, and monitor cpu temperature

### DIFF
--- a/bramble/Makefile.am
+++ b/bramble/Makefile.am
@@ -37,7 +37,9 @@ src_libbramble_libbramble_la_SOURCES = \
     src/libbramble/i2clinux.c \
     src/libbramble/i2cproto.h \
     src/libbramble/proc.c \
-    src/libbramble/proc.h
+    src/libbramble/proc.h \
+    src/libbramble/temp.c \
+    src/libbramble/temp.h
 
 powermanconfdir = $(sysconfdir)/powerman
 

--- a/bramble/Makefile.am
+++ b/bramble/Makefile.am
@@ -1,5 +1,9 @@
 ACLOCAL_AMFLAGS = -I config
 
+#if HAVE_SYSTEMD
+systemdsystemunit_DATA = etc/bramble.service
+#endif
+
 noinst_LTLIBRARIES = \
     src/libbramble/libbramble.la
 

--- a/bramble/config/adl_recursive_eval.m4
+++ b/bramble/config/adl_recursive_eval.m4
@@ -1,0 +1,19 @@
+dnl
+dnl  Unknown origin, but was presumably part of autoconf-archive at
+dnl   some point in the past.
+dnl
+dnl adl_RECURSIVE_EVAL(VALUE, RESULT)
+dnl =================================
+dnl Interpolate the VALUE in loop until it doesn't change,
+dnl and set the result to $RESULT.
+dnl WARNING: It's easy to get an infinite loop with some unsane input.
+AC_DEFUN([adl_RECURSIVE_EVAL],
+[_lcl_receval="$1"
+$2=`(test "x$prefix" = xNONE && prefix="$ac_default_prefix"
+     test "x$exec_prefix" = xNONE && exec_prefix="${prefix}"
+     _lcl_receval_old=''
+     while test "[$]_lcl_receval_old" != "[$]_lcl_receval"; do
+       _lcl_receval_old="[$]_lcl_receval"
+       eval _lcl_receval="\"[$]_lcl_receval\""
+     done
+     echo "[$]_lcl_receval")`])

--- a/bramble/config/systemd.m4
+++ b/bramble/config/systemd.m4
@@ -1,0 +1,47 @@
+dnl Probe for systemd libraries and installation paths.
+dnl
+dnl Provides the RRA_WITH_SYSTEMD_UNITDIR macro, which adds the
+dnl --with-systemdsystemunitdir configure flag, sets the systemdsystemunitdir
+dnl substitution variable, and provides the HAVE_SYSTEMD Automake conditional
+dnl to use to control whether to install unit files.
+dnl
+dnl Provides the RRA_LIB_SYSTEMD_DAEMON_OPTIONAL macro, which sets
+dnl SYSTEMD_CFLAGS and SYSTEMD_LIBS substitution variables if
+dnl libsystemd-daemon is available and defines HAVE_SD_NOTIFY.  pkg-config
+dnl support for libsystemd-daemon is required for it to be detected.
+dnl
+dnl Depends on the Autoconf macros that come with pkg-config.
+dnl
+dnl The canonical version of this file is maintained in the rra-c-util
+dnl package, available at <http://www.eyrie.org/~eagle/software/rra-c-util/>.
+dnl
+dnl Written by Russ Allbery <eagle@eyrie.org>
+dnl Copyright 2013, 2014
+dnl     The Board of Trustees of the Leland Stanford Junior University
+dnl
+dnl This file is free software; the authors give unlimited permission to copy
+dnl and/or distribute it, with or without modifications, as long as this
+dnl notice is preserved.
+
+dnl Determine the systemd system unit directory, along with a configure flag
+dnl to override, and sets @systemdsystemunitdir@.  Provides the Automake
+dnl HAVE_SYSTEMD Automake conditional.
+AC_DEFUN([RRA_WITH_SYSTEMD_UNITDIR],
+[AC_REQUIRE([PKG_PROG_PKG_CONFIG])
+ AS_IF([test x"$PKG_CONFIG" = x], [PKG_CONFIG=false])
+ AC_ARG_WITH([systemdsystemunitdir],
+    [AS_HELP_STRING([--with-systemdsystemunitdir=DIR],
+        [Directory for systemd service files])],
+    [],
+    [with_systemdsystemunitdir=\${prefix}$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
+ AS_IF([test x"$with_systemdsystemunitdir" != xno],
+    [AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])])
+ AM_CONDITIONAL([HAVE_SYSTEMD],
+    [test -n "$with_systemdsystemunitdir" -a x"$with_systemdsystemunitdir" != xno])])
+
+dnl Check for libsystemd-daemon and define SYSTEMD_DAEMON_{CFLAGS,LIBS} if it
+dnl is available.
+AC_DEFUN([RRA_LIB_SYSTEMD_DAEMON_OPTIONAL],
+[PKG_CHECK_EXISTS([libsystemd-daemon],
+    [PKG_CHECK_MODULES([SYSTEMD_DAEMON], [libsystemd-daemon])
+     AC_DEFINE([HAVE_SD_NOTIFY], 1, [Define if sd_notify is available.])])])

--- a/bramble/config/x_ac_expand_install_dirs.m4
+++ b/bramble/config/x_ac_expand_install_dirs.m4
@@ -1,0 +1,101 @@
+##*****************************************************************************
+## $Id: x_ac_expand_install_dirs.m4 494 2006-05-08 22:59:28Z dun $
+##*****************************************************************************
+#  AUTHOR:
+#    Chris Dunlap <cdunlap@llnl.gov>
+#
+#  SYNOPSIS:
+#    X_AC_EXPAND_INSTALL_DIRS
+#
+#  DESCRIPTION:
+#    Expand the installation directory variables.
+##*****************************************************************************
+
+AC_DEFUN([X_AC_EXPAND_INSTALL_DIRS], [
+  AC_MSG_CHECKING([installation directory variables])
+
+  _x_ac_expand_install_dirs_prefix="$prefix"
+  test "$prefix" = NONE && prefix="$ac_default_prefix"
+  _x_ac_expand_install_dirs_exec_prefix="$exec_prefix"
+  test "$exec_prefix" = NONE && exec_prefix="$prefix"
+
+  adl_RECURSIVE_EVAL(["$prefix"], [X_PREFIX])
+  AC_DEFINE_UNQUOTED([X_PREFIX], ["$X_PREFIX"],
+    [Expansion of the "prefix" installation directory.])
+  AC_SUBST([X_PREFIX])
+
+  adl_RECURSIVE_EVAL(["$exec_prefix"], [X_EXEC_PREFIX])
+  AC_DEFINE_UNQUOTED([X_EXEC_PREFIX], ["$X_EXEC_PREFIX"],
+    [Expansion of the "exec_prefix" installation directory.])
+  AC_SUBST([X_EXEC_PREFIX])
+
+  adl_RECURSIVE_EVAL(["$bindir"], [X_BINDIR])
+  AC_DEFINE_UNQUOTED([X_BINDIR], ["$X_BINDIR"],
+    [Expansion of the "bindir" installation directory.])
+  AC_SUBST([X_BINDIR])
+
+  adl_RECURSIVE_EVAL(["$sbindir"], [X_SBINDIR])
+  AC_DEFINE_UNQUOTED([X_SBINDIR], ["$X_SBINDIR"],
+    [Expansion of the "sbindir" installation directory.])
+  AC_SUBST([X_SBINDIR])
+
+  adl_RECURSIVE_EVAL(["$libexecdir"], [X_LIBEXECDIR])
+  AC_DEFINE_UNQUOTED([X_LIBEXECDIR], ["$X_LIBEXECDIR"],
+    [Expansion of the "libexecdir" installation directory.])
+  AC_SUBST([X_LIBEXECDIR])
+
+  adl_RECURSIVE_EVAL(["$datadir"], [X_DATADIR])
+  AC_DEFINE_UNQUOTED([X_DATADIR], ["$X_DATADIR"],
+    [Expansion of the "datadir" installation directory.])
+  AC_SUBST([X_DATADIR])
+
+  adl_RECURSIVE_EVAL(["$sysconfdir"], [X_SYSCONFDIR])
+  AC_DEFINE_UNQUOTED([X_SYSCONFDIR], ["$X_SYSCONFDIR"],
+    [Expansion of the "sysconfdir" installation directory.])
+  AC_SUBST([X_SYSCONFDIR])
+
+  adl_RECURSIVE_EVAL(["$sharedstatedir"], [X_SHAREDSTATEDIR])
+  AC_DEFINE_UNQUOTED([X_SHAREDSTATEDIR], ["$X_SHAREDSTATEDIR"],
+    [Expansion of the "sharedstatedir" installation directory.])
+  AC_SUBST([X_SHAREDSTATEDIR])
+
+  adl_RECURSIVE_EVAL(["$localstatedir"], [X_LOCALSTATEDIR])
+  AC_DEFINE_UNQUOTED([X_LOCALSTATEDIR], ["$X_LOCALSTATEDIR"],
+    [Expansion of the "localstatedir" installation directory.])
+  AC_SUBST([X_LOCALSTATEDIR])
+
+  adl_RECURSIVE_EVAL(["$runstatedir"], [X_RUNSTATEDIR])
+  AC_DEFINE_UNQUOTED([X_RUNSTATEDIR], ["$X_RUNSTATEDIR"],
+    [Expansion of the "runstatedir" installation directory.])
+  AC_SUBST([X_RUNSTATEDIR])
+
+  adl_RECURSIVE_EVAL(["$libdir"], [X_LIBDIR])
+  AC_DEFINE_UNQUOTED([X_LIBDIR], ["$X_LIBDIR"],
+    [Expansion of the "libdir" installation directory.])
+  AC_SUBST([X_LIBDIR])
+
+  adl_RECURSIVE_EVAL(["$includedir"], [X_INCLUDEDIR])
+  AC_DEFINE_UNQUOTED([X_INCLUDEDIR], ["$X_INCLUDEDIR"],
+    [Expansion of the "includedir" installation directory.])
+  AC_SUBST([X_INCLUDEDIR])
+
+  adl_RECURSIVE_EVAL(["$oldincludedir"], [X_OLDINCLUDEDIR])
+  AC_DEFINE_UNQUOTED([X_OLDINCLUDEDIR], ["$X_OLDINCLUDEDIR"],
+    [Expansion of the "oldincludedir" installation directory.])
+  AC_SUBST([X_OLDINCLUDEDIR])
+
+  adl_RECURSIVE_EVAL(["$infodir"], [X_INFODIR])
+  AC_DEFINE_UNQUOTED([X_INFODIR], ["$X_INFODIR"],
+    [Expansion of the "infodir" installation directory.])
+  AC_SUBST([X_INFODIR])
+
+  adl_RECURSIVE_EVAL(["$mandir"], [X_MANDIR])
+  AC_DEFINE_UNQUOTED([X_MANDIR], ["$X_MANDIR"],
+    [Expansion of the "mandir" installation directory.])
+  AC_SUBST([X_MANDIR])
+
+  prefix="$_x_ac_expand_install_dirs_prefix"
+  exec_prefix="$_x_ac_expand_install_dirs_exec_prefix"
+
+  AC_MSG_RESULT([yes])
+])

--- a/bramble/configure.ac
+++ b/bramble/configure.ac
@@ -15,6 +15,9 @@ AC_DEFINE([_GNU_SOURCE], 1,
 AC_PROG_CC_C99
 AM_PROG_CC_C_O
 
+X_AC_EXPAND_INSTALL_DIRS
+RRA_WITH_SYSTEMD_UNITDIR
+
 LT_INIT
 AC_HEADER_STDC
 
@@ -24,6 +27,7 @@ AC_SEARCH_LIBS([ev_run], [ev], [], [
 
 AC_CONFIG_FILES( \
   Makefile \
+  etc/bramble.service
 )
 
 AC_OUTPUT

--- a/bramble/etc/bramble.service.in
+++ b/bramble/etc/bramble.service.in
@@ -1,0 +1,10 @@
+[Unit]
+Description=Bramble load monitor
+
+[Service]
+ExecStart=@X_BINDIR@/bramble usage-bargraph
+SyslogIdentifier=bramble
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/bramble/src/libbramble/bramble.h
+++ b/bramble/src/libbramble/bramble.h
@@ -12,6 +12,7 @@
 
 #include "utils.h"
 #include "proc.h"
+#include "temp.h"
 
 #endif /* _BRAMBLE_H */
 

--- a/bramble/src/libbramble/temp.c
+++ b/bramble/src/libbramble/temp.c
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#if HAVE_CONFIG_H
+# include "config.h"
+#endif
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+
+#include "src/libbramble/bramble.h"
+
+#define PATH_TEMP "/sys/class/thermal/thermal_zone0/temp"
+
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
+int temp_read (double *temp)
+{
+    FILE *f;
+    char buf[32];
+    double val;
+
+    if (!(f = fopen (PATH_TEMP, "r")))
+        return -1;
+    if (fgets (buf, sizeof (buf), f) == NULL) {
+        fclose (f);
+        return -1;
+    }
+    fclose (f);
+
+    errno = 0;
+    val = strtod (buf, NULL);
+    if (errno > 0)
+        return -1;
+    if (temp)
+        *temp = val / 1000;
+    return 0;
+}
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */
+

--- a/bramble/src/libbramble/temp.h
+++ b/bramble/src/libbramble/temp.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#ifndef _BRAMBLE_TEMP_H
+#define _BRAMBLE_TEMP_H
+
+/* Read temperature in C
+ * Returns 0 on success, -1 on error.
+ */
+int temp_read (double *temp);
+
+#endif /* !_BRAMBLE_TEMP */
+
+// vi:ts=4 sw=4 expandtab


### PR DESCRIPTION
Problem: `bramble usage-bargraph` is turning out to be quite useful, but it has to be started manually.

Add a systemd unit file to start it automatically on system boot.

Also show the cpu temperature in the unused 5th column.