### PR TITLE
firmware: change gpio pins used for openocd

### DIFF
--- a/firmware/src/openocd_pi.cfg
+++ b/firmware/src/openocd_pi.cfg
@@ -1,5 +1,7 @@
 source [find interface/sysfsgpio-raspberrypi.cfg]
 transport select swd
+# override gpios for swclk swdio
+sysfsgpio_swd_nums 13 16
 
 #set FLASH_SIZE 0x20000
 source [find target/stm32f1x.cfg]


### PR DESCRIPTION
Problem: gpio 11 and 25 are the defaults used by openocd, but they
conflict with SPI0_SCLK and an interrupt pin required by seeed studio
2 channel CAN-FD board.

Choose another pair of GPIO pins that are less likely to be needed
by peripherals: gpio 16 and 13.