### PR TITLE
firmware: drop power flip flop

### DIFF
--- a/firmware/src/main.c
+++ b/firmware/src/main.c
@@ -44,12 +44,22 @@ static void init_task (void *args __attribute((unused)))
 
 int main (void)
 {
+    bool por_flag = false;
+
     rcc_clock_setup_in_hse_8mhz_out_72mhz ();    // Use this for "blue pill"
+
+    /* Pi power control subsystem needs to know if this is a board power-up
+     * vs other reset so it can set GLOBAL_EN to an appropriate initial state.
+     * N.B. power flags must be cleared since they persist across reset.
+     */
+    if ((RCC_CSR & RCC_CSR_PORRSTF))
+        por_flag = true;
+    RCC_CSR |= RCC_CSR_RMVF;
 
     blink_init ();
     matrix_init ();
     address_init ();
-    power_init ();
+    power_init (por_flag);
     serial_init ();
     canbus_init ();
     canservices_init ();

--- a/firmware/src/power.h
+++ b/firmware/src/power.h
@@ -3,7 +3,7 @@
 #ifndef _FIRMWARE_POWER_H
 #define _FIRMWARE_POWER_H
 
-void power_init (void);
+void power_init (bool por_flag);
 
 void power_set_state (bool enable); // can sleep
 bool power_get_state (void);


### PR DESCRIPTION
Problem: the power flip flop is no longer needed, since we
can tell the difference between a power on reset and other types
of reset by testing (RCC_CSR & PORRSTF).

Change pi power control code to use that technique instead of the
flip flop, which may be removed from future designs.