### PR TITLE
fix spurious power-on when stm32 warm starts

### DIFF
--- a/firmware/src/power.c
+++ b/firmware/src/power.c
@@ -69,7 +69,7 @@ void power_set_state (bool val)
         vTaskDelay (pdMS_TO_TICKS (1));
     }
 
-    /* Set GLOAL_EN to desired state, then wait for RUN_PG to change before
+    /* Set GLOBAL_EN to desired state, then wait for RUN_PG to change before
      * returning.
      */
     pi_global_en_set (val);


### PR DESCRIPTION
Problem: GLOBAL_EN glitches on a STM32 warm reset, sometimes turning on the pi PMIC.
    
On each power change, save the new power state in a backup data register that is preserved across a warm reset.  Initialize GLOBAL_EN to that value if not coming out of a power-on-reset.
