### PR TITLE
build: drop libtool, add copyright headers, add missing script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,8 +6,8 @@ SUBDIRS = .
 systemdsystemunit_DATA = etc/bramble.service
 #endif
 
-noinst_LTLIBRARIES = \
-    src/libbramble/libbramble.la
+noinst_LIBRARIES = \
+    src/libbramble/libbramble.a
 
 bin_PROGRAMS = \
     src/cmd/bramble
@@ -25,9 +25,9 @@ src_cmd_bramble_SOURCES = \
     src/cmd/shutdown.c
 
 src_cmd_bramble_LDADD = \
-    src/libbramble/libbramble.la
+    src/libbramble/libbramble.a
 
-src_libbramble_libbramble_la_SOURCES = \
+src_libbramble_libbramble_a_SOURCES = \
     src/libbramble/bramble.h \
     src/libbramble/utils.c \
     src/libbramble/utils.h \

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,11 +1,4 @@
 #!/bin/sh
-#
-# Run an extra libtoolize before autoreconf to ensure that
-# libtool macros can be found if libtool is in PATH, but its
-# macros are not in default aclocal search path.
-#
-echo "Running libtoolize --automake --copy ... "
-libtoolize --automake --copy || exit
 echo "Running autoreconf --verbose --install"
 autoreconf --force --verbose --install || exit
 echo "Now run ./configure."

--- a/configure.ac
+++ b/configure.ac
@@ -23,11 +23,10 @@ AC_SUBST([AX_POINT_VERSION])
 
 AC_PROG_CC
 AM_PROG_CC_C_O
+AC_PROG_RANLIB
 
 X_AC_EXPAND_INSTALL_DIRS
 RRA_WITH_SYSTEMD_UNITDIR
-
-LT_INIT
 
 AC_SEARCH_LIBS([ev_run], [ev], [], [
   AC_MSG_ERROR([Please install libev development package])

--- a/firmware/src/address.c
+++ b/firmware/src/address.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 /* address.c - read molliebus geographic slot address
  */

--- a/firmware/src/address.h
+++ b/firmware/src/address.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _FIRMWARE_ADDRESS_H
 #define _FIRMWARE_ADDRESS_H

--- a/firmware/src/blink.c
+++ b/firmware/src/blink.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 /* blink.c - blink PC13 LED to let the world know RTOS is running
  */

--- a/firmware/src/blink.h
+++ b/firmware/src/blink.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _FIRMWARE_BLINK_H
 #define _FIRMWARE_BLINK_H

--- a/firmware/src/canbus.c
+++ b/firmware/src/canbus.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 /* canbus.c - handle CAN network
  *

--- a/firmware/src/canbus.h
+++ b/firmware/src/canbus.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _FIRMWARE_CANBUS_H
 #define _FIRMWARE_CANBUS_H

--- a/firmware/src/canservices.c
+++ b/firmware/src/canservices.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #include "FreeRTOS.h"
 #include "task.h"

--- a/firmware/src/canservices.h
+++ b/firmware/src/canservices.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _FIRMWARE_CANSERVICES_H
 #define _FIRMWARE_CANSERVICES_H

--- a/firmware/src/i2c.c
+++ b/firmware/src/i2c.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 /* i2c.c - I2C2 (follower) connected to pi (leader)
  *

--- a/firmware/src/i2c.h
+++ b/firmware/src/i2c.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _FIRMWARE_I2C_H
 #define _FIRMWARE_I2C_H

--- a/firmware/src/main.c
+++ b/firmware/src/main.c
@@ -1,3 +1,12 @@
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
+
 #include <string.h>
 
 #include "FreeRTOS.h"

--- a/firmware/src/matrix.c
+++ b/firmware/src/matrix.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 /* matrix.c - 5x7 LED matrix attached to max7219 on SPI2
  *

--- a/firmware/src/matrix.h
+++ b/firmware/src/matrix.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _FIRMWARE_MATRIX_H
 #define _FIRMWARE_MATRIX_H

--- a/firmware/src/power.c
+++ b/firmware/src/power.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 /* power.c - control power of raspberry pi
  *

--- a/firmware/src/power.h
+++ b/firmware/src/power.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _FIRMWARE_POWER_H
 #define _FIRMWARE_POWER_H

--- a/firmware/src/rtc.c
+++ b/firmware/src/rtc.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 /* rtc.c - real time clock
  */

--- a/firmware/src/rtc.h
+++ b/firmware/src/rtc.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _FIRMWARE_RTC_H
 #define _FIRMWARE_RTC_H

--- a/firmware/src/serial.c
+++ b/firmware/src/serial.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 /* serial.c - USART 1 connected to pi console
  *

--- a/firmware/src/serial.h
+++ b/firmware/src/serial.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _FIRMWARE_SERIAL_H
 #define _FIRMWARE_SERIAL_H

--- a/firmware/src/trace.c
+++ b/firmware/src/trace.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 /* Print to SWO trace output.
  * Access with "stlink-trace -c 72".

--- a/firmware/src/trace.h
+++ b/firmware/src/trace.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _FIRMWARE_TRACE_H
 #define _FIRMWARE_TRACE_H

--- a/scripts/debbuild.sh
+++ b/scripts/debbuild.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+PACKAGE=bramble
+USER=$(git config --get user.name)
+DEBFULLNAME=$USER
+EMAIL=$(git config --get user.email)
+DEBEMAIL=$EMAIL
+
+SRCDIR=${1:-$(pwd)}
+
+die() { echo "debbuild: $@" >&2; exit 1; }
+log() { echo "debbuild: $@"; }
+
+test -z "$USER" && die "User name not set in git-config"
+test -z "$EMAIL" && die "User email not set in git-config"
+
+log "Running make dist"
+make dist >/dev/null || exit 1
+
+log "Building package from latest dist tarball"
+tarball=$(ls -tr *.tar.gz | tail -1)
+version=$(echo $tarball | sed "s/${PACKAGE}-\(.*\)\.tar\.gz/\1/")
+
+rm -rf debbuild
+mkdir -p debbuild && cd debbuild
+
+mv ../$tarball .
+
+log "Unpacking $tarball"
+tar xvfz $tarball >/dev/null
+
+log "Creating debian directory and files"
+cd ${PACKAGE}-${version}
+cp -a ${SRCDIR}/debian . || die "failed to copy debian dir"
+
+export DEBEMAIL DEBFULLNAME
+log "Creating debian/changelog"
+dch --create --package=$PACKAGE --newversion $version build tree release
+
+log "Running debian-buildpackage -b"
+dpkg-buildpackage -b
+log "Check debbuild directory for results"

--- a/src/cmd/bramble.c
+++ b/src/cmd/bramble.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 # include "config.h"

--- a/src/cmd/canping.c
+++ b/src/cmd/canping.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 # include "config.h"

--- a/src/cmd/cansnoop.c
+++ b/src/cmd/cansnoop.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 # include "config.h"

--- a/src/cmd/console.c
+++ b/src/cmd/console.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 /* console.c - helper for conman
  *

--- a/src/cmd/led.c
+++ b/src/cmd/led.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 # include "config.h"

--- a/src/cmd/power.c
+++ b/src/cmd/power.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 /* power.c - helper for powerman
  *

--- a/src/cmd/shutdown.c
+++ b/src/cmd/shutdown.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 /* shutdown.c - os friendly shutdown by slot
  */

--- a/src/cmd/slot.c
+++ b/src/cmd/slot.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 # include "config.h"

--- a/src/cmd/usage_bargraph.c
+++ b/src/cmd/usage_bargraph.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 # include "config.h"

--- a/src/cmd/version.c
+++ b/src/cmd/version.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 # include "config.h"

--- a/src/libbramble/bramble.h
+++ b/src/libbramble/bramble.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _BRAMBLE_H
 #define _BRAMBLE_H

--- a/src/libbramble/canlinux.c
+++ b/src/libbramble/canlinux.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 # include "config.h"

--- a/src/libbramble/canlinux.h
+++ b/src/libbramble/canlinux.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _BRAMBLE_CANLINUX_H
 #define _BRAMBLE_CANLINUX_H

--- a/src/libbramble/canmsg.h
+++ b/src/libbramble/canmsg.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _BRAMBLE_CANMSG_H
 #define _BRAMBLE_CANMSG_H

--- a/src/libbramble/canobj.c
+++ b/src/libbramble/canobj.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #include <unistd.h>
 #include <poll.h>

--- a/src/libbramble/canobj.h
+++ b/src/libbramble/canobj.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _BRAMBLE_CANOBJ_H
 #define _BRAMBLE_CANOBJ_H

--- a/src/libbramble/nvram.c
+++ b/src/libbramble/nvram.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 # include "config.h"

--- a/src/libbramble/nvram.h
+++ b/src/libbramble/nvram.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _BRAMBLE_NVRAM_H
 #define _BRAMBLE_NVRAM_H

--- a/src/libbramble/proc.c
+++ b/src/libbramble/proc.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 # include "config.h"

--- a/src/libbramble/proc.h
+++ b/src/libbramble/proc.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _BRAMBLE_PROC_H
 #define _BRAMBLE_PROC_H

--- a/src/libbramble/temp.c
+++ b/src/libbramble/temp.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 # include "config.h"

--- a/src/libbramble/temp.h
+++ b/src/libbramble/temp.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _BRAMBLE_TEMP_H
 #define _BRAMBLE_TEMP_H

--- a/src/libbramble/utils.c
+++ b/src/libbramble/utils.c
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #if HAVE_CONFIG_H
 # include "config.h"

--- a/src/libbramble/utils.h
+++ b/src/libbramble/utils.h
@@ -1,4 +1,11 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
 
 #ifndef _BRAMBLE_UTILS_H
 #define _BRAMBLE_UTILS_H

--- a/src/libbramble/version.h
+++ b/src/libbramble/version.h
@@ -1,0 +1,32 @@
+/************************************************************\
+ * Copyright 2023 Jim Garlick <garlick.jim@gmail.com>
+ *
+ * This file is part of the pi cluster II project
+ * https://github.com/worlickwerx/pi-cluster-two
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+\************************************************************/
+
+#ifndef _BRAMBLE_VERSION_H
+#define _BRAMBLE_VERSION_H
+
+/* The VERSION_STRING may include a "-N-hash" suffix from git describe
+ * if this snapshot is not tagged.  This is not reflected in VERSION_PATCH.
+ */
+#define BRAMBLE_VERSION_STRING    "0.1.0-350-g6fff23f"
+#define BRAMBLE_VERSION_MAJOR     0
+#define BRAMBLE_VERSION_MINOR     1
+#define BRAMBLE_VERSION_PATCH     0
+
+/* The version in 3 bytes, for numeric comparison.
+ */
+#define BRAMBLE_VERSION_HEX       ((BRAMBLE_VERSION_MAJOR << 16) | \
+                                   (BRAMBLE_VERSION_MINOR << 8) | \
+                                   (BRAMBLE_VERSION_PATCH << 0))
+
+
+#endif /* !_BRAMBLE_VERSION_H */
+
+/*
+ * vi:ts=4 sw=4 expandtab
+ */


### PR DESCRIPTION
Problem: deb cannot be built after most recent PR due to a missing script

Add the script.  Also, simplify the Makefile.am by dropping libtool support, since we aren't installing libraries or opening modules.  Finally, add some missing copyright headers to source code.