### PR TITLE
firmware: select smart default for flash

### DIFF
--- a/firmware/Makefile.am
+++ b/firmware/Makefile.am
@@ -1,5 +1,7 @@
 .NOTPARALLEL:
 
+.PHONY: flash
+
 AM_CPPFLAGS = \
     -I$(srcdir) \
     -I$(srcdir)/.. \
@@ -113,8 +115,6 @@ librtos_librtos_a_CPPFLAGS = \
 
 flash: bramble.fw
 	$(srcdir)/scripts/bramble-fw-update bramble.fw
-flash5: bramble.fw
-	$(srcdir)/scripts/bramble-fw-update -t pi5 bramble.fw
 
 all-local:
 	$(SIZE) bramble.fw

--- a/firmware/scripts/bramble-fw-update
+++ b/firmware/scripts/bramble-fw-update
@@ -29,6 +29,20 @@ stlink_config() {
 EOT
 }
 
+guess_config() {
+    case "$(tr -d '\000' </sys/firmware/devicetree/base/model)" in
+        "Raspberry Pi 5"*)
+            echo pi5
+            ;;
+        "Raspberry Pi"*)
+            echo pi
+            ;;
+        *)
+            echo stlink
+            ;;
+    esac
+}
+
 while getopts "t:" opt; do
     case "$opt" in
     t)
@@ -41,7 +55,7 @@ while getopts "t:" opt; do
     esac
     shift
 done
-test -n "$topt" || topt=pi
+test -n "$topt" || topt=$(guess_config)
 fwpath=$1; shift
 test -n "$fwpath" || fwpath=/lib/firmware/bramble.fw
 test -r "$fwpath" || die "could not read from $fwpath"


### PR DESCRIPTION
Problem: one cannot update firmware on a mixture of pi5 and other models using pdsh -a bramble-fw-update because the 5 needs a different argument.

Check /sys/firmware/devicetree/base/model when selecting a default, if the -t option is not used.