### PR TITLE
firmware: clear address from matrix after 2s

### DIFF
--- a/firmware/src/main.c
+++ b/firmware/src/main.c
@@ -42,7 +42,8 @@ static void init_task (void *args __attribute((unused)))
     vTaskDelay (pdMS_TO_TICKS (200));
 
     matrix_set_char (addrchr[addr % 16]);
-    vTaskDelay (pdMS_TO_TICKS (1000));
+    vTaskDelay (pdMS_TO_TICKS (2000));
+    matrix_set_char (' '); // clear
 
     /* init complete - block forever
      */


### PR DESCRIPTION
Problem: when a pi is off for a long time, leaving the bus address up there just wastes power and looks dumb.

Clear it after 2s.