### PR TITLE
pi-carrier: add plot script for JLCPCB 4-layer

### DIFF
--- a/hardware/Makefile.am
+++ b/hardware/Makefile.am
@@ -4,5 +4,6 @@ SUBDIRS = \
 
 check_SCRIPTS = \
 	scripts/plot.sh \
+	scripts/plot_jlc4.sh \
 	scripts/run_drc.sh \
 	scripts/run_erc.sh

--- a/hardware/pi-carrier/Makefile.am
+++ b/hardware/pi-carrier/Makefile.am
@@ -10,7 +10,7 @@ all-local: cam.zip
 endif
 
 cam.zip: eurocard.kicad_pcb
-	$(abs_top_srcdir)/scripts/plot.sh $< $@
+	$(abs_top_srcdir)/scripts/plot_jlc4.sh $< $@
 
 clean-local:
 	$(RM) -f cam.zip

--- a/hardware/scripts/plot_jlc4.sh
+++ b/hardware/scripts/plot_jlc4.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# https://jlcpcb.com/help/article/362-how-to-generate-gerber-and-drill-files-in-kicad-7
+
+die() {
+    echo $* >&2
+    exit 1
+}
+
+if test $# -ne 2; then
+    echo Usage plot_jlc4.sh pcbfile zipfile>&2
+    exit 1
+fi
+pcbfile=$(realpath $1)
+zipfile=$2
+
+tmpdir=$(mktemp -d) || die "could not create output directory"
+
+pushd $tmpdir
+    kicad-cli pcb export gerbers \
+        --layers=F.Cu,B.Cu,In1.Cu,In2.Cu,F.Paste,B.Paste,F.Silkscreen,B.Silkscreen,F.Mask,B.Mask,Edge.Cuts,F.Fab,B.Fab \
+        --subtract-soldermask \
+        --no-x2 \
+        $pcbfile
+    test $? -eq 0 || die "could not export gerber files"
+    rm -f *.gbrjob
+
+    kicad-cli pcb export drill \
+        --format=excellon \
+        --excellon-separate-th \
+	--excellon-oval-format=alternate \
+	--map-format=ps \
+	--drill-origin=absolute \
+	--excellon-units=mm \
+	--excellon-zeros-format=decimal \
+        $pcbfile
+    test $? -eq 0 || die "could not export drill files"
+popd
+
+echo Generating $zipfile
+find $tmpdir -type f -print | zip --quiet --junk-paths $zipfile -@
+test $? -eq 0 || die "error creating zip archive"
+rm -rf $tmpdir


### PR DESCRIPTION
Problem: plot script assumes 2 layers and uses PCBWAY values.

Create a new script for 4-layer JLCPCB.
Include the Fab layers with instructions for diff pair impedance.