### PR TITLE
firmware: fix pi5 power issue

### DIFF
--- a/firmware/src/power.c
+++ b/firmware/src/power.c
@@ -88,11 +88,12 @@ void power_set_state (bool val)
 {
     /* If GLOBAL_EN is high and RUN_PG is low, the pi may have turned off
      * its own PMIC (e.g. shutdown -h).  In that case, GLOBAL_EN needs to be
-     * pulsed low for >= 1ms.
+     * turned off for a while before it can be turned on.  1ms was reliable
+     * for the pi4 but the pi5 requires more time so conservatively wait 100ms.
      */
     if (val && pi_global_en_get () && !pi_run_pg_get ()) {
         pi_global_en_set (false);
-        vTaskDelay (pdMS_TO_TICKS (1));
+        vTaskDelay (pdMS_TO_TICKS (100));
     }
 
     /* Set GLOBAL_EN to desired state, then wait for RUN_PG to change before

--- a/hardware/scripts/run_drc.sh
+++ b/hardware/scripts/run_drc.sh
@@ -3,7 +3,7 @@
 kicad-cli pcb drc \
     -o pcb_drc.rpt \
     --exit-code-violations \
-    --severity-all \
+    --severity-error \
     $DRC_INPUT
 result=$?
 test $result -eq 0 || cat pcb_drc.rpt >&2


### PR DESCRIPTION
Problem: after shutdown -h, the power button won't turn on a pi5.

On the pi5 we don't have access to the PMIC so RUN_PG is pulled to the pi's 3V3 and GLOBAL_EN is connected to an external load switch. shutdown -h turns off the PMIC and therefore RUN_PG, but GLOBAL_EN reads high since it was never set low by pi-carrier firmware.

This is like the situation on the pi4 where GLOBAL_EN has to be pulsed low for 1ms after a shutdown -h, but in the pi5 case we cannot signal the PMIC directly so all we can do is remove external power to get it back to its initial power-on state.  This takes longer than 1ms.

Raise the 1ms delay to 100ms.